### PR TITLE
Add , to list of split characters when parsing vn

### DIFF
--- a/source/CjClutter.ObjLoader.Loader/TypeParsers/NormalParser.cs
+++ b/source/CjClutter.ObjLoader.Loader/TypeParsers/NormalParser.cs
@@ -22,7 +22,7 @@ namespace ObjLoader.Loader.TypeParsers
 
         public override void Parse(string line)
         {
-            string[] parts = line.Split(' ');
+            string[] parts = line.Split(' ', ',');
 
             float x = parts[0].ParseInvariantFloat();
             float y = parts[1].ParseInvariantFloat();

--- a/source/CjClutter.ObjLoader.Test/Program.cs
+++ b/source/CjClutter.ObjLoader.Test/Program.cs
@@ -25,6 +25,7 @@ namespace ObjLoader.Test
             Console.WriteLine(stopwatch.Elapsed);
             
             PrintResult(result);
+            Console.Read();
         }
 
         private static void PrintResult(LoadResult result)


### PR DESCRIPTION
www.tinkercad.com .obj would not parse as the vn/normal lines are ended with ','

Also sneaking in a Console.Read() so we can run from inside Visual Studio with preset command line arguments
