### PR TITLE
Adding package.json to make it easy to put as a dependency on projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "net-objloader",
+  "version": "1.0.0",
+  "description": "Objloader is a simple Wavefront .obj and .mtl loader",
+  "main": "no-entry",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chrisjansson/ObjLoader.git"
+  },
+  "keywords": [
+    "wavefront",
+    "obj",
+    "c#",
+    ".net",
+    "loader",
+    "mtl"
+  ],
+  "author": "Chris Jansson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/chrisjansson/ObjLoader/issues"
+  },
+  "homepage": "https://github.com/chrisjansson/ObjLoader#readme"
+}


### PR DESCRIPTION
I just added the package.json to be able to reference it as a dependency directly from github on our company projects. I don't plan to be modifying the library in the future, but who knows.
Anyway, I would be very happy if you could include this little file on your repo.
Thanks for your fine work!

PS: I tried to preserve as much of the information from what I could find on your project. If you see anything needing changing, you can do so (obviously, but anyway).