### PR TITLE
When setting material, match case sensitive first then ignore case

### DIFF
--- a/source/CjClutter.ObjLoader.Loader/Common/StringExtensions.cs
+++ b/source/CjClutter.ObjLoader.Loader/Common/StringExtensions.cs
@@ -20,6 +20,11 @@ namespace ObjLoader.Loader.Common
             return str.Equals(s, StringComparison.OrdinalIgnoreCase);
         }
 
+        public static bool EqualsOrdinal(this string str, string s)
+        {
+            return str.Equals(s, StringComparison.Ordinal);
+        }
+
         public static bool IsNullOrEmpty(this string str)
         {
             return string.IsNullOrEmpty(str);

--- a/source/CjClutter.ObjLoader.Loader/Data/DataStore/DataStore.cs
+++ b/source/CjClutter.ObjLoader.Loader/Data/DataStore/DataStore.cs
@@ -86,7 +86,8 @@ namespace ObjLoader.Loader.Data.DataStore
 
         public void SetMaterial(string materialName)
         {
-            var material = _materials.SingleOrDefault(x => x.Name.EqualsOrdinalIgnoreCase(materialName));
+            var material = _materials.SingleOrDefault(x => x.Name.EqualsOrdinal(materialName)) ??
+                           _materials.SingleOrDefault(x => x.Name.EqualsOrdinalIgnoreCase(materialName));
             PushGroupIfNeeded();
             _currentGroup.Material = material;
         }


### PR DESCRIPTION
For some OBJ files I notice that more than one material name matches because some material's names are the same but case sensitive.